### PR TITLE
Fix API result validation and cache bounds

### DIFF
--- a/src/app/api/api-routes.test.ts
+++ b/src/app/api/api-routes.test.ts
@@ -9,10 +9,12 @@ import {
   vi,
 } from 'vitest';
 
+import { GET as dashboardGET } from '@/app/api/dashboard/route';
 import { GET as trendGET } from '@/app/api/dashboard/trend/route';
 import { GET as latencyGET } from '@/app/api/latency/route';
 import { GET as lengthGET } from '@/app/api/length/recommend/route';
 import { GET as overlapGET } from '@/app/api/up/overlap/route';
+import { GET as videoGET } from '@/app/api/video/route';
 import { GET as wordcloudGET } from '@/app/api/wordcloud/route';
 import {
   buildAggregations,
@@ -61,15 +63,20 @@ const mockResults: Record<string, ReturnType<typeof buildCrawlResult>> = {
 };
 
 // 動態替換的 hooks（給 catch path 測試用）
+const listCalls: string[] = [];
+const byNameCalls: string[] = [];
+const aggByNameCalls: string[] = [];
 let listImpl: () => Promise<string[]> = async () => mockList.slice();
 let byNameImpl: (
   name: string
 ) => Promise<ReturnType<typeof buildCrawlResult>> = async (name: string) => {
+  byNameCalls.push(name);
   if (!mockResults[name]) {
     throw new Error('Unknown filename: ' + name);
   }
   return mockResults[name];
 };
+let aggByNameImpl: () => Promise<null> = async () => null;
 
 vi.mock('@/common/libs/result-data.server', async () => {
   const actual = await vi.importActual<
@@ -77,17 +84,100 @@ vi.mock('@/common/libs/result-data.server', async () => {
   >('@/common/libs/result-data.server');
   return {
     ...actual,
-    fetchResultList: () => listImpl(),
+    fetchAggByName: (name: string) => {
+      aggByNameCalls.push(name);
+      return aggByNameImpl();
+    },
+    fetchAggLatest: () => Promise.resolve(null),
+    fetchResultList: () => {
+      listCalls.push('list');
+      return listImpl();
+    },
     fetchResultByName: (name: string) => byNameImpl(name),
   };
 });
 
 beforeAll(() => {});
-afterEach(() => {});
+afterEach(() => {
+  listCalls.length = 0;
+  byNameCalls.length = 0;
+  aggByNameCalls.length = 0;
+});
 afterAll(() => {});
 
 const callRoute = (handler: (req: Request) => Promise<Response>, url: string) =>
   handler(new Request(url));
+
+describe('GET /api/dashboard', () => {
+  it('rejects unknown file before fetching aggregations or results', async () => {
+    const res = await callRoute(
+      dashboardGET,
+      'http://localhost/api/dashboard?file=../../main/package.json?x='
+    );
+    expect(res.status).toBe(404);
+    expect(await res.text()).toBe('Unknown filename');
+    expect(aggByNameCalls).toEqual([]);
+    expect(byNameCalls).toEqual([]);
+  });
+
+  it('allows a known file and returns dashboard data', async () => {
+    const res = await callRoute(
+      dashboardGET,
+      'http://localhost/api/dashboard?file=2026-01-15'
+    );
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.file).toBe('2026-01-15');
+    expect(aggByNameCalls).toEqual(['2026-01-15']);
+    expect(byNameCalls).toEqual(['2026-01-15']);
+  });
+});
+
+describe('GET /api/video', () => {
+  it('rejects invalid mode before fetching the result list', async () => {
+    const res = await callRoute(
+      videoGET,
+      'http://localhost/api/video?mode=foo&value=UP0'
+    );
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe('Invalid mode');
+    expect(listCalls).toEqual([]);
+    expect(byNameCalls).toEqual([]);
+  });
+
+  it('rejects oversized value before fetching the result list', async () => {
+    const res = await callRoute(
+      videoGET,
+      `http://localhost/api/video?mode=up&value=${'x'.repeat(121)}`
+    );
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe('Value too long');
+    expect(listCalls).toEqual([]);
+    expect(byNameCalls).toEqual([]);
+  });
+
+  it('rejects unknown file before fetching results', async () => {
+    const res = await callRoute(
+      videoGET,
+      'http://localhost/api/video?mode=up&value=UP0&file=../../main/package.json'
+    );
+    expect(res.status).toBe(404);
+    expect(await res.text()).toBe('Unknown filename');
+    expect(byNameCalls).toEqual([]);
+  });
+
+  it('allows a known file and returns matching videos', async () => {
+    const res = await callRoute(
+      videoGET,
+      'http://localhost/api/video?mode=up&value=UP0&file=2026-01-15'
+    );
+    const data = await res.json();
+    expect(res.status).toBe(200);
+    expect(data.file).toBe('2026-01-15');
+    expect(data.count).toBeGreaterThan(0);
+    expect(byNameCalls).toEqual(['2026-01-15']);
+  });
+});
 
 describe('GET /api/dashboard/trend', () => {
   it('returns an empty payload when list is empty', async () => {

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -16,6 +16,10 @@ import {
 
 const cache = createFiveMinCache<DashboardAgg>();
 
+function isKnownResultFile(filename: string, list: string[]): boolean {
+  return list.includes(filename);
+}
+
 export async function GET(req: Request) {
   return withRouteErrorHandler('DASHBOARD', async () => {
     const url = new URL(req.url);
@@ -25,10 +29,10 @@ export async function GET(req: Request) {
     const rawFilename = url.searchParams.get('file');
     const filename = rawFilename?.replace(/ /g, '+') ?? null;
 
-    let targetFile = filename;
-    if (!targetFile) {
-      const list = await fetchResultList();
-      targetFile = list[0] ?? null;
+    const list = await fetchResultList();
+    const targetFile = filename ?? list[0] ?? null;
+    if (filename && !isKnownResultFile(filename, list)) {
+      return new NextResponse('Unknown filename', { status: 404 });
     }
     if (!targetFile) {
       return new NextResponse('No crawl data', { status: 404 });

--- a/src/app/api/video/route.ts
+++ b/src/app/api/video/route.ts
@@ -16,29 +16,45 @@ type VideoResponse = {
 };
 
 const cache = createFiveMinCache<VideoResponse>();
+const VIDEO_MODES = ['up', 'channel', 'tag'] as const;
+const MAX_VIDEO_VALUE_LENGTH = 120;
+
+function isVideoMode(mode: string): mode is (typeof VIDEO_MODES)[number] {
+  return VIDEO_MODES.includes(mode as (typeof VIDEO_MODES)[number]);
+}
 
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const mode = url.searchParams.get('mode');
-  const value = url.searchParams.get('value');
+  const value = url.searchParams.get('value')?.trim();
   const filename = url.searchParams.get('file');
 
   if (!mode || !value) {
     return new NextResponse('Missing mode or value', { status: 400 });
   }
-
-  const cacheKey = `video:${mode}:${value}:${filename ?? ''}`;
-  const hit = cache.get(cacheKey);
-  if (hit) {
-    return NextResponse.json(hit);
+  if (!isVideoMode(mode)) {
+    return new NextResponse('Invalid mode', { status: 400 });
+  }
+  if (value.length > MAX_VIDEO_VALUE_LENGTH) {
+    return new NextResponse('Value too long', { status: 400 });
   }
 
   return withRouteErrorHandler('VIDEO_RELATED', async () => {
     const list = await fetchResultList();
     const target = filename || list[0];
+    if (filename && !list.includes(filename)) {
+      return new NextResponse('Unknown filename', { status: 404 });
+    }
     if (!target) {
       return new NextResponse('No crawl data', { status: 404 });
     }
+
+    const cacheKey = `video:${mode}:${value}:${target}`;
+    const hit = cache.get(cacheKey);
+    if (hit) {
+      return NextResponse.json(hit);
+    }
+
     const data = await fetchResultByName(target);
 
     let matches;
@@ -52,8 +68,6 @@ export async function GET(req: Request) {
       );
     } else if (mode === 'tag') {
       matches = data.video.filter((v) => v.tags.ordinaryTags.includes(value));
-    } else {
-      return new NextResponse('Invalid mode', { status: 400 });
     }
 
     const payload: VideoResponse = {

--- a/src/common/libs/routes/create-cached-route.test.ts
+++ b/src/common/libs/routes/create-cached-route.test.ts
@@ -33,6 +33,26 @@ describe('RouteCache', () => {
     expect(c.get('a')).toBeUndefined();
   });
 
+  it('evicts the oldest entry when max entries is exceeded', () => {
+    const c = new RouteCache<string>(1000, 2);
+    c.set('a', 'a');
+    c.set('b', 'b');
+    c.set('c', 'c');
+    expect(c.get('a')).toBeUndefined();
+    expect(c.get('b')).toBe('b');
+    expect(c.get('c')).toBe('c');
+  });
+
+  it('cleans expired entries before set', () => {
+    const c = new RouteCache<string>(1000, 3);
+    c.set('a', 'a');
+    vi.advanceTimersByTime(1001);
+    c.set('b', 'b');
+    const internal = c as unknown as { cache: Map<string, unknown> };
+    expect(internal.cache.has('a')).toBe(false);
+    expect(internal.cache.size).toBe(1);
+  });
+
   it('createFiveMinCache uses 5-minute TTL', () => {
     const c = createFiveMinCache<string>();
     c.set('a', 'value');

--- a/src/common/libs/routes/create-cached-route.ts
+++ b/src/common/libs/routes/create-cached-route.ts
@@ -13,7 +13,10 @@ export type CacheEntry<T> = { data: T; at: number };
 export class RouteCache<T> {
   private readonly cache = new Map<string, CacheEntry<T>>();
 
-  constructor(private readonly ttlMs: number) {}
+  constructor(
+    private readonly ttlMs: number,
+    private readonly maxEntries = 200
+  ) {}
 
   get(key: string): T | undefined {
     const hit = this.cache.get(key);
@@ -26,7 +29,21 @@ export class RouteCache<T> {
   }
 
   set(key: string, data: T): void {
-    this.cache.set(key, { data, at: Date.now() });
+    const now = Date.now();
+    for (const [entryKey, entry] of this.cache) {
+      if (now - entry.at >= this.ttlMs) {
+        this.cache.delete(entryKey);
+      }
+    }
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
+    }
+    this.cache.set(key, { data, at: now });
+    while (this.cache.size > this.maxEntries) {
+      const oldest = this.cache.keys().next();
+      if (oldest.done) break;
+      this.cache.delete(oldest.value);
+    }
   }
 }
 
@@ -56,6 +73,6 @@ export async function withRouteErrorHandler(
  * Convenience: create a fresh cache with a 5-minute TTL.
  * Centralizes the (previously duplicated) constant.
  */
-export function createFiveMinCache<T>(): RouteCache<T> {
-  return new RouteCache<T>(5 * 60 * 1000);
+export function createFiveMinCache<T>(maxEntries?: number): RouteCache<T> {
+  return new RouteCache<T>(5 * 60 * 1000, maxEntries);
 }

--- a/src/common/libs/routes/length-recommend.test.ts
+++ b/src/common/libs/routes/length-recommend.test.ts
@@ -55,6 +55,12 @@ describe('parseLengthParams', () => {
     expect(r).toEqual({ ok: true, type: 'up', value: 'foo', window: 30 });
   });
 
+  it('trims value before returning it', () => {
+    const r = parseLengthParams(makeUrl('type=up&value=%20foo%20'));
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.value).toBe('foo');
+  });
+
   it('returns 400 for invalid type', () => {
     const r = parseLengthParams(makeUrl('type=foo&value=bar'));
     expect(r.ok).toBe(false);
@@ -63,6 +69,18 @@ describe('parseLengthParams', () => {
 
   it('returns 400 when value is missing', () => {
     const r = parseLengthParams(makeUrl('type=up&value='));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(400);
+  });
+
+  it('returns 400 when value is only whitespace', () => {
+    const r = parseLengthParams(makeUrl('type=up&value=%20%20'));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.status).toBe(400);
+  });
+
+  it('returns 400 when value is too long', () => {
+    const r = parseLengthParams(makeUrl(`type=up&value=${'x'.repeat(121)}`));
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.status).toBe(400);
   });

--- a/src/common/libs/routes/length-recommend.ts
+++ b/src/common/libs/routes/length-recommend.ts
@@ -10,6 +10,7 @@ import { parseWindowParam } from '@/common/libs/routes/shared';
 
 export const LENGTH_TYPES = ['up', 'channel', 'tag'] as const;
 export type LengthType = (typeof LENGTH_TYPES)[number];
+export const MAX_LENGTH_VALUE_LENGTH = 120;
 
 type VideoLike = {
   UP: string;
@@ -64,12 +65,15 @@ export type LengthRecommendPayload = {
 
 export function parseLengthParams(url: URL): ParseLengthResult {
   const type = url.searchParams.get('type') ?? '';
-  const value = url.searchParams.get('value') ?? '';
+  const value = (url.searchParams.get('value') ?? '').trim();
   if (!LENGTH_TYPES.includes(type as LengthType)) {
     return { ok: false, status: 400, message: 'Invalid type' };
   }
   if (!value) {
     return { ok: false, status: 400, message: 'Missing value' };
+  }
+  if (value.length > MAX_LENGTH_VALUE_LENGTH) {
+    return { ok: false, status: 400, message: 'Value too long' };
   }
   const window = parseWindowParam(url, 'window', { default: 30, max: 90 });
   return { ok: true, type: type as LengthType, value, window };

--- a/src/common/libs/routes/up-overlap.test.ts
+++ b/src/common/libs/routes/up-overlap.test.ts
@@ -38,6 +38,12 @@ describe('parseOverlapParams', () => {
     expect(p.limit).toBe(200);
   });
 
+  it('caps minChannels and minCount at domain-specific maxima', () => {
+    const p = parseOverlapParams(makeUrl('minChannels=999999&minCount=999999'));
+    expect(p.minChannels).toBe(20);
+    expect(p.minCount).toBe(1000);
+  });
+
   it('falls back to defaults for non-numeric', () => {
     const p = parseOverlapParams(
       makeUrl('window=abc&minChannels=xyz&minCount=NaN&limit=oops')

--- a/src/common/libs/routes/up-overlap.ts
+++ b/src/common/libs/routes/up-overlap.ts
@@ -35,12 +35,12 @@ export const OVERLAP_DEFAULTS = {
   minChannels: {
     default: 2,
     min: 2,
-    max: Number.MAX_SAFE_INTEGER,
+    max: 20,
   } satisfies IntRangeOpts,
   minCount: {
     default: 2,
     min: 1,
-    max: Number.MAX_SAFE_INTEGER,
+    max: 1000,
   } satisfies IntRangeOpts,
   limit: { default: 50, min: 1, max: 200 } satisfies IntRangeOpts,
 };


### PR DESCRIPTION
## Summary
- validate dashboard and video result filenames against `fetchResultList()` before any aggregation/result fetch
- reject invalid video modes and oversized public `value` parameters before remote work
- bound route caches and cap public cache-key dimensions for length recommendation and UP overlap

## Scope
Fixes the 5 reportable Codex Security findings:
- `/api/dashboard?file=` unvalidated result filename
- `/api/video?file=` unvalidated result filename
- length recommendation unbounded public `value` cache dimension
- video filter unbounded public `value` cache dimension
- UP overlap overly wide `minChannels` / `minCount` cache dimensions

Rejected/hardening notes for workflow, client media, extension/mobile config are intentionally not included in this PR.

## Tests
- `npm test -- src/app/api/api-routes.test.ts src/common/libs/routes/create-cached-route.test.ts src/common/libs/routes/length-recommend.test.ts src/common/libs/routes/up-overlap.test.ts`
- `npm test`
- `npm run lint` (passes with existing warnings)
